### PR TITLE
Feature/cli login

### DIFF
--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -19,6 +19,10 @@ export default class Deploy extends CustomCommand {
 
   static flags = {
     ...CustomCommand.globalFlags,
+    pipeline: oclifFlags.boolean({
+      char: 'p',
+      description: 'Deploys the app in pipeline mode.',
+    }),
     yes: oclifFlags.boolean({ char: 'y', description: 'Answers yes to all prompts.' }),
     force: oclifFlags.boolean({
       char: 'f',
@@ -44,17 +48,17 @@ export default class Deploy extends CustomCommand {
     if (featureFlags.FEATURE_FLAG_DEPLOY_PLUGIN) {
       const {
         args: { appId },
-        flags: { yes, force },
+        flags: { yes, force, pipeline },
       } = this.parse(Deploy)
 
-      await newAppsDeploy(appId, { yes, force })
+      await newAppsDeploy(appId, { yes, force }, pipeline)
     } else {
       const {
         args: { appId },
-        flags: { yes },
+        flags: { yes, pipeline },
       } = this.parse(Deploy)
 
-      await oldAppsDeploy(appId, { yes })
+      await oldAppsDeploy(appId, { yes }, pipeline)
     }
   }
 }

--- a/src/modules/newDeploy.ts
+++ b/src/modules/newDeploy.ts
@@ -27,6 +27,7 @@ const switchToVendorMessage = (vendor: string): string => {
 }
 
 const promptDeploy = (app: string) => promptConfirm(`Are you sure you want to deploy app ${app}`)
+
 const promptDeployForce = () =>
   promptConfirm(`Are you sure you want to ignore the minimum testing period of 7 minutes after publish?`)
 
@@ -90,18 +91,22 @@ const prepareDeploy = async (app, originalAccount, originalWorkspace: string, fo
 }
 
 // @ts-ignore
-export default async (optionalApp: string, options) => {
+export default async (optionalApp: string, options, pipeline: boolean) => {
   const preConfirm = options.y || options.yes
   const force = options.f || options.force || false
 
   const { account: originalAccount, workspace: originalWorkspace } = SessionManager.getSingleton()
   const app = optionalApp || (await ManifestEditor.getManifestEditor()).appLocator
 
-  if (!preConfirm && !(await promptDeploy(app))) {
+  if (!pipeline && !preConfirm && !(await promptDeploy(app))) {
     return
   }
 
-  if (force && !(await promptDeployForce())) {
+  if (pipeline) {
+    logger.info(`Deploying app ${app} in pipeline mode`)
+  }
+
+  if (!pipeline && force && !(await promptDeployForce())) {
     return
   }
 

--- a/src/modules/oldDeploy.ts
+++ b/src/modules/oldDeploy.ts
@@ -70,15 +70,17 @@ const prepareDeploy = async (app, originalAccount, originalWorkspace: string): P
 }
 
 // @ts-ignore
-export default async (optionalApp: string, options) => {
+export default async (optionalApp: string, options, pipeline) => {
   const preConfirm = options.y || options.yes
 
   const { account: originalAccount, workspace: originalWorkspace } = SessionManager.getSingleton()
   const app = optionalApp || (await ManifestEditor.getManifestEditor()).appLocator
 
-  if (!preConfirm && !(await promptDeploy(app))) {
+  if (!pipeline && !preConfirm && !(await promptDeploy(app))) {
     return
   }
+
+  logger.info('Deploying app in pipeline mode')
 
   logger.debug(`Deploying app ${app}`)
 

--- a/src/modules/oldDeploy.ts
+++ b/src/modules/oldDeploy.ts
@@ -80,7 +80,9 @@ export default async (optionalApp: string, options, pipeline) => {
     return
   }
 
-  logger.info('Deploying app in pipeline mode')
+  if (pipeline) {
+    logger.info('Deploying app in pipeline mode')
+  }
 
   logger.debug(`Deploying app ${app}`)
 


### PR DESCRIPTION
# This pull request complements the [Toolbelt PR](https://github.com/vtex/toolbelt/pull/1211)

#### What is the purpose of this pull request?
The purpose of this pull request is to introduce pipeline support in the VTEX TOOLBELT CLI, aiming to optimize the workflow in CI/CD pipelines. This is achieved by adding a -p or --pipeline flag to the login command, allowing automatic login using VTEX_API_KEY and VTEX_API_TOKEN environment variables, and also adding this flag to the release, publish, deprecate in toolbelt pr, and supporting deploy command in this PR.

This commands to remove unnecessary confirmations in these automated contexts.

#### What problem is this solving?
This change addresses the issue of having to manually confirm actions or perform logins, which is impractical in continuous integration and delivery environments, where automatic and interaction-free processes are essential for efficiency and scalability.

#### How should this be manually tested?

To manually test this feature, you can follow these steps:
``` vtex deploy -p ```
or
``` vtex deploy --pipeline ```

#### Screenshots or example usage
Below are examples of how the commands can be executed with the new -p or --pipeline flag, illustrating the practical use of this new feature:

**this examples is using unix/linux environment**

``` vtex deploy -p ```
or
``` vtex deploy --pipeline  ```



#### Types of changes
- [ ] Refactor (non-breaking change that only makes the code better)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.

#### Chores checklist
- [] Update `CHANGELOG.md`